### PR TITLE
Fixed GDI-DE localization issue.

### DIFF
--- a/geonode/templates/catalogue/full_metadata.xml
+++ b/geonode/templates/catalogue/full_metadata.xml
@@ -1,4 +1,5 @@
 {% load thesaurus %}
+{% load l10n %}
 <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gco="http://www.isotc211.org/2005/gco" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd">
    <gmd:fileIdentifier>
      <gco:CharacterString>{{layer.uuid}}</gco:CharacterString>
@@ -449,6 +450,7 @@
          <gmd:EX_Extent>
            <gmd:geographicElement>
              <gmd:EX_GeographicBoundingBox>
+              {% localize off %}
                <gmd:westBoundLongitude>
                  <gco:Decimal>{{layer.ll_bbox.0}}</gco:Decimal>
                </gmd:westBoundLongitude>
@@ -461,6 +463,7 @@
                <gmd:northBoundLatitude>
                  <gco:Decimal>{{layer.ll_bbox.3}}</gco:Decimal>
                </gmd:northBoundLatitude>
+              {% endlocalize %}
              </gmd:EX_GeographicBoundingBox>
            </gmd:geographicElement>
          </gmd:EX_Extent>


### PR DESCRIPTION
Fixed the issue where GDI-DE compliance was failing because of a localization issue i.e., the extent segment of the ISO metadata was being generated with a comma instead of a decimal. Now the ISO metadata is being generated with decimal irrespective of the language selection.

Resolves https://github.com/Thuenen-GeoNode-Development/Sprints/issues/6