### PR TITLE
Fixed incorrect parsing of date from DOI cross-reference.

### DIFF
--- a/geonode/apps/thuenen_app/templatetags/doi_fields.py
+++ b/geonode/apps/thuenen_app/templatetags/doi_fields.py
@@ -15,8 +15,6 @@ def get_doi_title_and_date(doi_value):
     """
     try:
         doi = extract_doi(doi_value)
-        if not doi:
-            raise Exception('Unable to extract doi')
         url = f"https://doi.org/{doi}"
         headers = {
             "Accept": "application/vnd.citationstyles.csl+json, application/rdf+xml"
@@ -27,17 +25,38 @@ def get_doi_title_and_date(doi_value):
         if response.status_code == 200:
             data = response.json()
             title = data.get("title", "Missing title")
-            date = data.get("issued", {})
-            year, month, day = date['date-parts'][0]
-            date_obj = datetime(year, month, day)
-            return {"title": title, "date": date_obj, "doi": doi}
+            date_obj = extract_date(data)
+
+            return {"title": title, "date": date_obj}
         else:
-            raise Exception("Failed to fetch the requested DOI")
+            raise Exception("Unable to fetch the requested DOI")
     except Exception as e:
         logger.warning(f"Unable to get ISO metadata URL: {str(e)}")
-        return {"title": "No title", "date": "No date"} 
+        return {"title": "Missing title", "date": None} 
 
 def extract_doi(url):
     pattern = r'10\.(.*)'
     match = re.search(pattern, url)
-    return match.group(0) if match else None
+    if not match:
+        raise Exception('Unable to extract doi')
+    return match.group(0)
+
+def extract_date(response_data):
+    try:
+        date_parts = response_data.get('issued').get('date-parts', [[]])[0]
+        
+        if len(date_parts) == 1:
+            year = int(date_parts[0])
+            return datetime(year, 1, 1)
+        elif len(date_parts) == 2:
+            year, month = map(int, date_parts)
+            return datetime(year, month, 1)
+        elif len(date_parts) == 3:
+            year, month, day = map(int, date_parts)
+            return datetime(year, month, day)
+        else:
+            raise ValueError("Invalid date-parts structure.")
+    
+    except (TypeError, ValueError) as e:
+        logger.warning(f"Error parsing date: {str(e)}")
+        return None

--- a/geonode/geonode/catalogue/templates/catalogue/full_metadata.xml
+++ b/geonode/geonode/catalogue/templates/catalogue/full_metadata.xml
@@ -525,6 +525,7 @@
                    <gmd:title>
                      <gco:CharacterString>{{ doi_data.title }}</gco:CharacterString>
                    </gmd:title>
+                   {% if doi_data.date %}
                    <gmd:date>
                     <gmd:CI_Date>
                       <gmd:date>
@@ -535,6 +536,7 @@
                       </gmd:dateType>
                     </gmd:CI_Date>
                    </gmd:date>
+                   {% endif %}
                    <gmd:identifier>
                      <gmd:MD_Identifier>
                        <gmd:code>


### PR DESCRIPTION
The date from DOII cross-reference sometimes only includes year, and not month and date. This PR defaults the month and date to '1'.