### PR TITLE
About button and about page for the Holisoils subsite

### DIFF
--- a/geonode/apps/thuenen_app/apps.py
+++ b/geonode/apps/thuenen_app/apps.py
@@ -12,6 +12,8 @@ def run_setup_hooks(*args, **kwargs):
     template_dir = os.path.join(LOCAL_ROOT, "templates")
     settings.TEMPLATES[0]["DIRS"].insert(0, template_dir)
 
+    from subsites.views import SubsiteCatalogueViewSet
+
     urlpatterns += [
         re_path(
             r"^legal_notice/$",
@@ -28,7 +30,12 @@ def run_setup_hooks(*args, **kwargs):
             TemplateView.as_view(template_name="privacy-cookies.html"),
             name="privacy-cookies",
         ),
+        re_path(r"^(?P<subsite>[^/]*)/about-holisoils/$",
+            SubsiteCatalogueViewSet.as_view(template_name="about-holisoils.html"),
+            name="about-holisoils",
+        ),
         re_path(r"", include("subsites.urls")),
+        
     ]
 
 

--- a/geonode/apps/thuenen_app/templates/about-holisoils.html
+++ b/geonode/apps/thuenen_app/templates/about-holisoils.html
@@ -1,0 +1,10 @@
+{% extends "geonode_base.html" %}
+
+
+{% block body_outer %}
+<h1>About</h1>
+<p>In the course of the HoliSoils project, a lot of data was collected and maps were created. The purpose of this portal is to make the results accessible to anyone who is interested.
+    The current focus of the portal is on European maps of soil properties in forests. A map of peatlands in the Baltic states and a biodiversity map will follow.
+    The maps are made to be discovered. On the right-hand side there will always be a statistical overview of the data visible in the current map section. This overview changes continuously when the map section is changed by zooming in.
+    Try it out!</p>
+{% endblock %}

--- a/geonode/geonode/templates/subsites/holisoils/geonode-mapstore-client/snippets/menu_item.html
+++ b/geonode/geonode/templates/subsites/holisoils/geonode-mapstore-client/snippets/menu_item.html
@@ -3,12 +3,16 @@
     {% if menu_item.type == 'link' %}
         <li>
             <a
-                id={{ menu_item.label | slugify }}
-                href="{% if menu_item.label == 'Home' %}/holisoils{% else %}{{ menu_item.href }}{% endif %}"
+                id="{{ menu_item.label | slugify }}"
+                href="{% if menu_item.label == 'Home' %}/holisoils/about-holisoils{% else %}{{ menu_item.href }}{% endif %}"
                 target="{{ menu_item.target }}"
                 class="nav-link btn btn-{{variant|default:'default'}}"
             >
+            {% if menu_item.label == 'Home' %}
+            About
+            {% else %}
                 {% trans menu_item.label %}
+            {% endif %}
             </a>
         </li>
     {% endif %}


### PR DESCRIPTION
Here is an addition of the new About page for the Holisoils subsite with some placeholder content. Also, the Home button is changed from "Home" to "About" and now leads to the newly created about page. 